### PR TITLE
Fix package URL in 13.4.1

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
         // Targets can depend on other targets in this package, and on products in packages this package depends on.
-.binaryTarget(name: "Tapjoy", url: "https://sdk.tapjoy.com/release/13.4.1/SwiftPackage/Tapjoy.xcframework.zip", checksum: "27cb39109a7b86efbbbc83b297089e1e17b04c8cf41638cc324091feecd434c9"),
+.binaryTarget(name: "Tapjoy", url: "https://sdk.tapjoy.com/releases/13.4.1/SwiftPackage/Tapjoy.xcframework.zip", checksum: "27cb39109a7b86efbbbc83b297089e1e17b04c8cf41638cc324091feecd434c9"),
     ]
 )
 


### PR DESCRIPTION
The URL in Package.swift has a typo which results in SPM unable to resolve the package